### PR TITLE
Fix: Correctly format DeepSeek model name

### DIFF
--- a/crewai-web-ui/src/app/api/generate/route.ts
+++ b/crewai-web-ui/src/app/api/generate/route.ts
@@ -246,7 +246,7 @@ export async function POST(request: Request) {
             'Authorization': `Bearer ${apiKey}`,
           },
           body: JSON.stringify({
-            model: llmModel, // Use the original llmModel which is like "deepseek/chat" or "deepseek/reasoner"
+            model: llmModel.startsWith('deepseek/') ? llmModel.substring('deepseek/'.length) : llmModel,
             messages: [{ role: "user", content: fullPrompt }],
             temperature: 0,
             stream: false, // Explicitly disable streaming as per assumptions


### PR DESCRIPTION
The DeepSeek API expects model names like 'deepseek-chat' or 'deepseek-reasoner', without the 'deepseek/' prefix.

This commit modifies the API call to remove the 'deepseek/' prefix from the llmModel variable before sending it to the DeepSeek API.