### PR TITLE
Okay, I've refactored the code to centralize static model configurati…

### DIFF
--- a/crewai-web-ui/src/app/api/models/route.ts
+++ b/crewai-web-ui/src/app/api/models/route.ts
@@ -1,58 +1,24 @@
 import { NextResponse } from 'next/server';
+// Import ModelConfig and staticModels from the new configuration file
+import { ModelConfig, staticModels } from '../../../config/models.config';
 
-interface Model {
-  id: string;
-  name: string;
-}
+// Use ModelConfig directly or alias it. Let's use it directly for clarity.
+// The previous Model interface was: interface Model { id: string; name: string; }
+// ModelConfig is { id: string; name: string; }, so it's compatible.
 
 export async function GET() {
-  let allModels: Model[] = [];
+  // Initialize with static models from the configuration file
+  let allModels: ModelConfig[] = [...staticModels];
 
-  // 1. Base Models (placeholders or non-discoverable)
-  // These are models that we want to ensure are always in the list,
-  // or for services where SDKs don't yet support listing models.
-  const baseModels: Model[] = [
-    // Add DeepSeek models here
-    { id: "deepseek/chat", name: "DeepSeek Chat" },
-    { id: "deepseek/reasoner", name: "DeepSeek Reasoner" },
-  ];
-  allModels = [...baseModels];
-
-  // 2. Gemini Models (currently hardcoded, as no list API in Google AI SDK for Node.js)
-  // Use the exact model names that the GoogleGenerativeAI SDK expects for the 'model' parameter.
-  const geminiModelIds = [
-    "gemini-2.5-flash-preview-05-20", // New Gemini model
-    // "gemini-1.5-flash-latest" // Example if we want to add Flash models
-  ];
-
-  const geminiModels: Model[] = geminiModelIds.map(id => {
-    // Create a more human-readable name from the ID
-    let name = `Gemini ${id.replace(/-/g, ' ')}`;
-    // Custom naming for the new model to ensure "Preview 05 20" is preserved as is,
-    // rather than "Preview 05 20" becoming "Preview 05 20" due to toUpperCase logic on each word.
-    if (id === "gemini-2.5-flash-preview-05-20") {
-        name = "Gemini 2.5 Flash Preview 05 20";
-    } else {
-        name = name.split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
-        if (name.includes("Latest")) name = name.replace("Latest", "(Latest)");
-    }
-    return {
-      id: id, // The ID used by the API
-      name: name
-    };
-  });
-  allModels = [...allModels, ...geminiModels];
-
-  // 3. Ollama Models (fetched via API)
+  // Ollama Models (fetched via API) - This part remains largely the same
   const ollamaApiBaseUrl = process.env.OLLAMA_API_BASE_URL;
   if (ollamaApiBaseUrl) {
-    // console.log(`Fetching Ollama models from ${ollamaApiBaseUrl}/api/tags`); // Removed console log
     try {
-      const response = await fetch(`${ollamaApiBaseUrl}/api/tags`, { cache: 'no-store' }); // Disable cache for dynamic fetching
+      const response = await fetch(`${ollamaApiBaseUrl}/api/tags`, { cache: 'no-store' });
       if (response.ok) {
         const data = await response.json();
         if (data.models && Array.isArray(data.models)) {
-          const ollamaFetchedModels: Model[] = data.models.map((model: any) => {
+          const ollamaFetchedModels: ModelConfig[] = data.models.map((model: any) => {
             const modelNameParts = model.name.split(':');
             const baseName = modelNameParts[0];
             const tag = modelNameParts[1] || 'latest';
@@ -62,7 +28,6 @@ export async function GET() {
             };
           });
           allModels = [...allModels, ...ollamaFetchedModels];
-          // console.log(`Successfully fetched ${ollamaFetchedModels.length} Ollama models.`); // Removed console log
         } else {
           console.warn("Ollama API response was OK, but data.models was not as expected:", data);
         }
@@ -73,14 +38,12 @@ export async function GET() {
       console.error("Error fetching Ollama models:", error);
     }
   } else {
-    // console.log("OLLAMA_API_BASE_URL not set. Skipping Ollama model fetching."); // Removed console log
-    // Optionally, add a placeholder if OLLAMA_API_BASE_URL is not set but you still want an Ollama option
+    // Optionally, add a placeholder if OLLAMA_API_BASE_URL is not set
     allModels.push({ id: "ollama/not-configured", name: "Ollama (Not Configured)" });
   }
 
   // Remove duplicates by ID
-  // This is important if baseModels or other sources might overlap with fetched models
-  const uniqueModels = new Map<string, Model>();
+  const uniqueModels = new Map<string, ModelConfig>();
   allModels.forEach(model => {
     if (!uniqueModels.has(model.id)) {
       uniqueModels.set(model.id, model);

--- a/crewai-web-ui/src/config/models.config.ts
+++ b/crewai-web-ui/src/config/models.config.ts
@@ -1,0 +1,24 @@
+export interface ModelConfig {
+  id: string;
+  name: string;
+  // Add other properties like 'host' or 'url' if needed in the future
+}
+
+export const staticModels: ModelConfig[] = [
+  // DeepSeek Models
+  { id: "deepseek/chat", name: "deepseek-chat" },
+  { id: "deepseek/reasoner", name: "deepseek-reasoner" },
+
+  // Gemini Models
+  // Using the exact model IDs the GoogleGenerativeAI SDK expects.
+  // Names are made more human-readable.
+  {
+    id: "gemini-1.5-flash-preview-05-20", // Actual ID for API
+    name: "Gemini 1.5 Flash Preview 05 20" // Human-readable name
+  },
+  // Example for another Gemini model if it were static:
+  // {
+  //   id: "gemini-1.5-pro-latest",
+  //   name: "Gemini 1.5 Pro (Latest)"
+  // },
+];


### PR DESCRIPTION
…ons and update the DeepSeek names. Here's what I did:

- I created a new configuration file at `crewai-web-ui/src/config/models.config.ts` to store static model definitions (like DeepSeek and Gemini).
- I updated `crewai-web-ui/src/app/api/models/route.ts` so it now uses the model definitions from this new configuration file.
- I changed the DeepSeek model names to "deepseek-chat" and "deepseek-reasoner" as you requested.
- I made sure that Ollama models are still fetched dynamically from the local Ollama server and combined with the static models.
- This approach should make things easier to maintain by keeping all the model information in one place, and it also takes care of updating the DeepSeek model names.