### PR TITLE
Refactor: Extract Ollama model retrieval to a dedicated service

### DIFF
--- a/crewai-web-ui/src/app/api/models/route.ts
+++ b/crewai-web-ui/src/app/api/models/route.ts
@@ -1,50 +1,30 @@
 import { NextResponse } from 'next/server';
-// Import ModelConfig and staticModels from the new configuration file
 import { ModelConfig, staticModels } from '../../../config/models.config';
-
-// Use ModelConfig directly or alias it. Let's use it directly for clarity.
-// The previous Model interface was: interface Model { id: string; name: string; }
-// ModelConfig is { id: string; name: string; }, so it's compatible.
+import { fetchOllamaModels } from '../../../lib/ollama'; // Adjusted path
 
 export async function GET() {
-  // Initialize with static models from the configuration file
   let allModels: ModelConfig[] = [...staticModels];
+  let ollamaModels: ModelConfig[] = [];
 
-  // Ollama Models (fetched via API) - This part remains largely the same
   const ollamaApiBaseUrl = process.env.OLLAMA_API_BASE_URL;
+
   if (ollamaApiBaseUrl) {
-    try {
-      const response = await fetch(`${ollamaApiBaseUrl}/api/tags`, { cache: 'no-store' });
-      if (response.ok) {
-        const data = await response.json();
-        if (data.models && Array.isArray(data.models)) {
-          const ollamaFetchedModels: ModelConfig[] = data.models.map((model: any) => {
-            return {
-              id: `ollama/${model.name}`, // Prefix with ollama/ to namespace
-              name: `Ollama ${model.name}`
-            };
-          });
-          allModels = [...allModels, ...ollamaFetchedModels];
-        } else {
-          console.warn("Ollama API response was OK, but data.models was not as expected:", data);
-        }
-      } else {
-        console.warn(`Failed to fetch Ollama models. Status: ${response.status}, Body: ${await response.text()}`);
-        // Add specific error model entry if fetch was not ok
-        allModels.push({ id: "ollama/error", name: "Ollama (API Error - Check Connection/URL)" });
-      }
-    } catch (error: any) {
-      console.error("Error fetching Ollama models:", error.message, error.stack);
-      // Add specific error model entry if any other error occurred during fetch
+    console.log('[models/route.ts] OLLAMA_API_BASE_URL is defined. Attempting to fetch Ollama models.');
+    ollamaModels = await fetchOllamaModels(); // This function now handles its own detailed logging
+
+    if (ollamaModels.length === 0) {
+      // If fetchOllamaModels returns empty and URL was present, it indicates an error during fetch
+      console.warn('[models/route.ts] fetchOllamaModels returned no models, though OLLAMA_API_BASE_URL was set. Indicating API error.');
       allModels.push({ id: "ollama/error", name: "Ollama (API Error - Check Connection/URL)" });
+    } else {
+      allModels = [...allModels, ...ollamaModels];
     }
   } else {
-    // Optionally, add a placeholder if OLLAMA_API_BASE_URL is not set
-    console.warn("OLLAMA_API_BASE_URL environment variable is not defined. Ollama models will not be fetched.");
+    console.warn('[models/route.ts] OLLAMA_API_BASE_URL environment variable is not defined. Ollama models will not be fetched.');
     allModels.push({ id: "ollama/not-configured", name: "Ollama (Not Configured)" });
   }
 
-  // Remove duplicates by ID
+  // Remove duplicates by ID - important if staticModels somehow overlaps or if error models are added multiple times
   const uniqueModels = new Map<string, ModelConfig>();
   allModels.forEach(model => {
     if (!uniqueModels.has(model.id)) {


### PR DESCRIPTION
I've separated the logic for fetching Ollama models from the API route into a new `ollama.ts` service file. This should improve modularity and maintainability.

Key changes:
- I created `crewai-web-ui/src/lib/ollama.ts` containing a `fetchOllamaModels` function.
- I moved the Ollama API fetching, response handling, and model mapping logic into `fetchOllamaModels`.
- I added detailed console logging within `fetchOllamaModels` to trace:
    - Attempts to fetch.
    - Missing `OLLAMA_API_BASE_URL` configuration.
    - Successful fetch operations, including the number of models retrieved.
    - API errors (status codes, messages).
    - Exceptions during the fetch process.
    - Unexpected API response structures.
- I updated `crewai-web-ui/src/app/api/models/route.ts` to:
    - Import and use `fetchOllamaModels`.
    - Handle the return value of `fetchOllamaModels` to correctly integrate fetched models or appropriate error/not-configured models (`ollama/error`, `ollama/not-configured`) into the main model list.
- I ensured that the `ModelConfig` type is consistently used by importing it from `models.config.ts` in the new `ollama.ts` file.

The existing functionality of displaying models in the UI, including handling of special states like 'ollama/error' and 'ollama/not-configured', should remain unchanged.