### PR TITLE
Refactor: Remove all Ollama support and references

### DIFF
--- a/crewai-web-ui/src/app/api/models/route.ts
+++ b/crewai-web-ui/src/app/api/models/route.ts
@@ -1,50 +1,13 @@
 import { NextResponse } from 'next/server';
-// Import ModelConfig and staticModels from the new configuration file
 import { ModelConfig, staticModels } from '../../../config/models.config';
-
-// Use ModelConfig directly or alias it. Let's use it directly for clarity.
-// The previous Model interface was: interface Model { id: string; name: string; }
-// ModelConfig is { id: string; name: string; }, so it's compatible.
 
 export async function GET() {
   // Initialize with static models from the configuration file
   let allModels: ModelConfig[] = [...staticModels];
 
-  // Ollama Models (fetched via API) - This part remains largely the same
-  const ollamaApiBaseUrl = process.env.OLLAMA_API_BASE_URL;
-  if (ollamaApiBaseUrl) {
-    try {
-      const response = await fetch(`${ollamaApiBaseUrl}/api/tags`, { cache: 'no-store' });
-      if (response.ok) {
-        const data = await response.json();
-        if (data.models && Array.isArray(data.models)) {
-          const ollamaFetchedModels: ModelConfig[] = data.models.map((model: any) => {
-            return {
-              id: `ollama/${model.name}`, // Prefix with ollama/ to namespace
-              name: `Ollama ${model.name}`
-            };
-          });
-          allModels = [...allModels, ...ollamaFetchedModels];
-        } else {
-          console.warn("Ollama API response was OK, but data.models was not as expected:", data);
-        }
-      } else {
-        console.warn(`Failed to fetch Ollama models. Status: ${response.status}, Body: ${await response.text()}`);
-        // Add specific error model entry if fetch was not ok
-        allModels.push({ id: "ollama/error", name: "Ollama (API Error - Check Connection/URL)" });
-      }
-    } catch (error: any) {
-      console.error("Error fetching Ollama models:", error.message, error.stack);
-      // Add specific error model entry if any other error occurred during fetch
-      allModels.push({ id: "ollama/error", name: "Ollama (API Error - Check Connection/URL)" });
-    }
-  } else {
-    // Optionally, add a placeholder if OLLAMA_API_BASE_URL is not set
-    console.warn("OLLAMA_API_BASE_URL environment variable is not defined. Ollama models will not be fetched.");
-    allModels.push({ id: "ollama/not-configured", name: "Ollama (Not Configured)" });
-  }
+  // Ollama specific logic has been removed.
 
-  // Remove duplicates by ID
+  // Remove duplicates by ID (though less likely to be necessary without dynamic models)
   const uniqueModels = new Map<string, ModelConfig>();
   allModels.forEach(model => {
     if (!uniqueModels.has(model.id)) {

--- a/crewai-web-ui/src/app/page.tsx
+++ b/crewai-web-ui/src/app/page.tsx
@@ -42,7 +42,7 @@ export default function Home() {
         setAvailableModels(models);
         if (models.length > 0) {
           // Filter out non-selectable models before determining the default
-          const selectableModels = models.filter(model => model.id !== 'ollama/not-configured' && model.id !== 'ollama/error');
+          const selectableModels = models;
 
           if (selectableModels.length > 0) {
             // Prioritize the new Gemini model, then the first selectable model
@@ -192,7 +192,6 @@ export default function Home() {
             <option
               key={model.id}
               value={model.id}
-              disabled={model.id === 'ollama/not-configured' || model.id === 'ollama/error'}
             >
               {model.name}
             </option>


### PR DESCRIPTION
This commit removes all support for Ollama as a dynamic model provider from the application, following a change in your requirements.

Key changes:
- I deleted the Ollama service file `crewai-web-ui/src/lib/ollama.ts` and its containing directory.
- I modified `crewai-web-ui/src/app/api/models/route.ts` to:
    - Remove imports and calls related to Ollama model fetching.
    - Eliminate all logic for processing Ollama models, including environment variable checks for `OLLAMA_API_BASE_URL` and handling of special states like 'ollama/error' or 'ollama/not-configured'.
    - The API route now exclusively serves models from `staticModels`.
- I updated `crewai-web-ui/src/app/page.tsx` to:
    - Remove filtering conditions that specifically checked for 'ollama/not-configured' and 'ollama/error' model IDs during default model selection.
    - Remove the `disabled` attribute logic from model options that checked for these Ollama-specific IDs.

The application will now rely solely on the statically defined models in `models.config.ts`.