### PR TITLE
Refactor: Simplify prompt input handling and remove redundancy

### DIFF
--- a/crewai-web-ui/src/app/page.tsx
+++ b/crewai-web-ui/src/app/page.tsx
@@ -220,21 +220,17 @@ ${defaultPhase3PromptText}`;
     };
 
     if (phase === 1) {
-      payload.initialInput = initialInput; // Original user input
-      payload.phase1_prompt = phase1Prompt;
+      payload.initialInput = initialInput; // Original user input from component state
+      payload.phase1_prompt = phase1Prompt; // phase1Prompt from component state
     } else if (phase === 2) {
-      payload.initialInput = phase1Output || initialInput; // Output of P1
-      payload.phase2_prompt = phase2Prompt;
-      payload.previous_full_prompt = displayedPrompt; // Full prompt from Phase 1
-      payload.originalInitialInput = initialInput;
-      payload.phase1PromptText = phase1Prompt;
+      payload.initialInput = initialInput; // Original user input from component state
+      payload.phase1_prompt = phase1Prompt; // phase1Prompt from component state
+      payload.phase2_prompt = phase2Prompt; // phase2Prompt from component state
     } else if (phase === 3) {
-      payload.initialInput = phase2Output || phase1Output || initialInput; // Output of P2
-      payload.phase3_prompt = phase3Prompt;
-      payload.previous_full_prompt = displayedPrompt; // Full prompt from Phase 2
-      payload.originalInitialInput = initialInput;
-      payload.phase1PromptText = phase1Prompt;
-      payload.phase2PromptText = phase2Prompt;
+      payload.initialInput = initialInput; // Original user input from component state
+      payload.phase1_prompt = phase1Prompt; // phase1Prompt from component state
+      payload.phase2_prompt = phase2Prompt; // phase2Prompt from component state
+      payload.phase3_prompt = phase3Prompt; // phase3Prompt from component state
     }
 
     // Old console.log statements for specific phase generation have been removed.


### PR DESCRIPTION
This commit refactors the handling of user inputs for prompt construction, particularly in advanced mode.

Key changes:
- Removed `originalInitialInput` from the API payload and backend processing. The `initialInput` field now consistently holds the original user instruction across all modes and phases.
- Simplified prompt construction for advanced mode:
    - The backend now uses the user-provided prompt templates (`phase1_prompt`, `phase2_prompt`, `phase3_prompt` from the UI textareas) for each respective phase. If a user-provided template is empty, the system falls back to the default prompt file for that phase.
    - These resolved phase prompt templates are concatenated, followed by the `initialInput` (original user instruction), to form the final prompt sent to the LLM.
- Removed `phase1PromptText` and `phase2PromptText` from the API payload between frontend and backend, as the backend no longer requires the resolved text of previous prompts to be passed explicitly; it re-constructs the context using the provided phase templates.
- Updated frontend to send the correct payload structure for advanced mode phases, aligning with the backend changes.

This resolves ambiguity in input handling and streamlines the data flow for multi-phase prompt generation.