### PR TITLE
I've made an update to how scripts are executed.

### DIFF
--- a/crewai-web-ui/src/app/api/execute/route.ts
+++ b/crewai-web-ui/src/app/api/execute/route.ts
@@ -52,14 +52,19 @@ async function executePythonScript(scriptContent: string): Promise<{ stdout: str
     console.log(`Creating Docker container for image '${imageName}' with script from ${tempDir} for direct execution`);
     const container = await docker.createContainer({
       Image: imageName,
-      Cmd: ['python', 'script.py'],
-      WorkingDir: '/usr/src/app',
+      Cmd: ['python', '/run/script_dir/script.py'],
+      WorkingDir: '/workspace',
       HostConfig: {
         Mounts: [
           {
             Type: 'bind',
             Source: tempDir,
-            Target: '/usr/src/app'
+            Target: '/run/script_dir'
+          },
+          {
+            Type: 'bind',
+            Source: path.resolve(projectRoot, 'workspace'),
+            Target: '/workspace'
           }
         ],
         AutoRemove: true,

--- a/python-runner/Dockerfile
+++ b/python-runner/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.10-slim
 
 # Set working directory
-WORKDIR /usr/src/app
+WORKDIR /workspace
 
 # Install git for crewai dependencies that might need it
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This change modifies how the Python execution environment is launched.

Here are the key adjustments:
- I've set the working directory within the execution environment to `/workspace`.
- I've linked your local `./workspace` directory to `/workspace` inside the execution environment. This means Python scripts I run can now read from and write to a persistent workspace that you can also access.
- The Python script I generate on the fly is now placed at `/run/script_dir/script.py` (instead of the working directory) and run from there. This helps avoid any issues with the `/workspace` link.

These modifications ensure that any files saved by the Python scripts (for instance, to `.` or `./output.txt`, which will end up as `/workspace/output.txt`) will be available to you in your local `./workspace` directory.

Regarding accessing your main computer from within the execution environment: Standard Docker networking capabilities should be used. For Docker Desktop (Mac/Windows), scripts can access services running on your computer via the DNS name `host.docker.internal`. For Linux, your computer's IP address on the `docker0` bridge (commonly `172.17.0.1`) can be used. No specific `NetworkMode` changes were made, as the default bridge mode is generally sufficient and more secure than host mode.