### PR TITLE
Enable Dockerized components to connect to host Ollama server

### DIFF
--- a/crewai-web-ui/src/app/api/execute/route.ts
+++ b/crewai-web-ui/src/app/api/execute/route.ts
@@ -133,7 +133,9 @@ async function executePythonScript(scriptContent: string): Promise<ExecutionResu
         HostConfig: {
           Mounts: [{ Type: 'bind', Source: workspaceDir, Target: '/workspace' }],
           AutoRemove: true,
+          ExtraHosts: ['host.docker.internal:host-gateway'], // Added this line
         },
+        Env: ['OLLAMA_HOST=http://host.docker.internal:11434'], // Added this line
         Tty: false,
       });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "3000:3000"
     environment:
       NODE_ENV: development # Or 'production' for production builds
+    extra_hosts: # Add this section
+      - "host.docker.internal:host-gateway" # Add this line
     # Mount the source code for development (optional, good for local dev)
     # For production, you'd typically not mount the source
     volumes:


### PR DESCRIPTION
This commit addresses the issue where Docker containers (both the `web` service and the dynamically generated `python-runner`) could not connect to an Ollama server running on your host machine.

Changes:

1.  **`docker-compose.yml`:**
    *   Added `extra_hosts: ["host.docker.internal:host-gateway"]` to the `web` service. This allows the Next.js backend (when run under `docker-compose`) to use `http://host.docker.internal:11434` (e.g., via the `OLLAMA_API_BASE_URL` environment variable) to communicate with your host's Ollama instance for tasks like fetching model lists.

2.  **`crewai-web-ui/src/app/api/execute/route.ts`:**
    *   Modified the `createContainer` call for the `python-runner` service.
    *   Added `ExtraHosts: ['host.docker.internal:host-gateway']` to `HostConfig` to allow network access to the host.
    *   Added `Env: ['OLLAMA_HOST=http://host.docker.internal:11434']` to the container options. This makes the Ollama server address available as an environment variable to the `crewai` Python script, which should use it to establish a connection with Ollama.

These changes ensure that both the main web application and the Python execution environment can reliably connect to an Ollama instance running on the Docker host, using `host.docker.internal`. You should set `OLLAMA_API_BASE_URL=http://host.docker.internal:11434` in your `.env` file for the `web` service.