### PR TITLE
Update python-runner Dockerfile to include development tools

### DIFF
--- a/python-runner/Dockerfile
+++ b/python-runner/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /workspace
 # Install git for crewai dependencies that might need it
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
+# Install build-essential for gcc and other development tools
+RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
+
 # Install crewai and crewai-tools
 # Ensure these are the latest versions or specific versions as per requirements
 RUN pip install --no-cache-dir crewai crewai-tools


### PR DESCRIPTION
The python-runner Docker image was missing essential development tools like gcc, leading to compilation errors for Python packages with C extensions.

This commit updates the Dockerfile to install the `build-essential` package, which includes gcc and other necessary tools. This resolves the compilation errors and allows packages with C extensions to be installed correctly.