### PR TITLE
feat: Unify script output, display Docker cmd, refine server logs

### DIFF
--- a/crewai-web-ui/src/app/api/execute/route.ts
+++ b/crewai-web-ui/src/app/api/execute/route.ts
@@ -28,6 +28,7 @@ interface ExecutePythonScriptSetupResult {
   preHostRunResult: StageOutput;
   overallStatus: 'success' | 'failure';
   error?: string;
+  dockerCommand?: string;
 }
 
 // Modified function to process collected Docker output and finalize execution
@@ -327,7 +328,7 @@ async function executePythonScript(scriptContent: string): Promise<ExecutePython
       overallStatus = 'failure';
       topLevelError = `Docker image build failed: ${buildError.message}`;
       // Early exit for Docker build failure
-      return { preHostRunResult, overallStatus, error: topLevelError };
+    return { preHostRunResult, overallStatus, error: topLevelError, dockerCommand: "" }; // Return empty dockerCommand on failure
     }
 
     // --- Docker Container Setup ---
@@ -348,7 +349,7 @@ async function executePythonScript(scriptContent: string): Promise<ExecutePython
     try {
       const container = await docker.createContainer({
         Image: imageName,
-        Cmd: ['/bin/sh', '-c', dockerCommand],
+        Cmd: ['/bin/sh', '-c', dockerCommand], // dockerCommand is defined above
         WorkingDir: '/workspace',
         HostConfig: {
           Mounts: [{ Type: 'bind', Source: workspaceDir, Target: '/workspace' }],
@@ -365,20 +366,21 @@ async function executePythonScript(scriptContent: string): Promise<ExecutePython
       await container.start();
       console.log(`Container for ${imageName} started.`);
 
-      return { container, stream, preHostRunResult, overallStatus };
+      return { container, stream, preHostRunResult, overallStatus, dockerCommand }; // Return dockerCommand
 
     } catch (dockerErr: any) {
       console.error("Error setting up or starting Docker container:", dockerErr);
       overallStatus = 'failure';
       topLevelError = `Docker container setup/start error: ${dockerErr.message}`;
-      return { preHostRunResult, overallStatus, error: topLevelError };
+      return { preHostRunResult, overallStatus, error: topLevelError, dockerCommand }; // Return dockerCommand even on error
     }
 
   } catch (topLevelCatchError: any) { // Catch errors from fs operations, etc.
     console.error("Top-level error in executePythonScript setup:", topLevelCatchError);
     overallStatus = 'failure';
     topLevelError = `Unhandled setup error: ${topLevelCatchError.message}`;
-    return { preHostRunResult, overallStatus, error: topLevelError };
+    // In this case, dockerCommand might not have been defined, so ensure it's part of the return if needed or set to empty
+    return { preHostRunResult, overallStatus, error: topLevelError, dockerCommand: "" };
   }
 }
 
@@ -415,36 +417,56 @@ export async function POST(request: Request) {
 
     console.log("Docker setup successful. Starting to stream logs and process final result...");
 
-    const { container, stream: dockerStream, preHostRunResult, overallStatus: setupOverallStatus, error: setupError } = setupResult;
+    const { container, stream: dockerStream, preHostRunResult, overallStatus: setupOverallStatus, error: setupError, dockerCommand: retrievedDockerCommand } = setupResult;
 
     const readableStream = new ReadableStream({
       async start(controller) {
+        if (retrievedDockerCommand) {
+          controller.enqueue(`DOCKER_COMMAND: ${retrievedDockerCommand}\n`);
+        }
+
         const stdoutChunks: Buffer[] = [];
         const stderrChunks: Buffer[] = [];
 
         dockerStream!.on('data', (chunk: Buffer) => {
           try {
-            // Demultiplex Docker stream (first byte indicates type: 1 for stdout, 2 for stderr)
-            // The rest of the chunk is the actual data.
             if (chunk.length > 8) {
               const type = chunk[0];
               const payload = chunk.slice(8);
+              const payloadString = payload.toString('utf-8');
 
-              // Log to server console
-              console.log(`Docker Stream (to client, type ${type}):`, payload.toString('utf-8'));
-              // Enqueue for client
-              controller.enqueue(`LOG: ${payload.toString('utf-8')}`);
+              // Server-side console logging (as per new feedback)
+              if (type === 2) { // stderr
+                // ANSI escape code for red text
+                console.log(`[31m%s[0m`, payloadString.endsWith('\n') ? payloadString.slice(0, -1) : payloadString);
+              } else { // stdout and other types
+                console.log(payloadString.endsWith('\n') ? payloadString.slice(0, -1) : payloadString);
+              }
 
-              if (type === 1) stdoutChunks.push(payload);
-              else if (type === 2) stderrChunks.push(payload);
+              // Existing client-side enqueue logic
+              if (type === 1) { // stdout
+                controller.enqueue(`LOG: ${payloadString}`);
+                stdoutChunks.push(payload);
+              } else if (type === 2) { // stderr
+                controller.enqueue(`LOG_ERROR: ${payloadString}`);
+                stderrChunks.push(payload);
+              } else {
+                controller.enqueue(`LOG_UNKNOWN_TYPE_${type}: ${payloadString}`);
+                // Still collect unknown types in stdout for now, or create a separate bucket
+                stdoutChunks.push(payload);
+              }
             } else {
-              // Should not happen with TTY=false, but good to log if it does
+              // For very short chunks (unexpected with TTY=false, but handle defensively)
               const rawChunkStr = chunk.toString('utf-8');
-              console.log("Docker Stream (raw, short chunk):", rawChunkStr);
-              controller.enqueue(`LOG: ${rawChunkStr}`);
+              // Server-side log for raw/short chunk
+              console.log(rawChunkStr.endsWith('\n') ? rawChunkStr.slice(0, -1) : rawChunkStr);
+              // Client-side enqueue for raw/short chunk
+              controller.enqueue(`LOG_RAW: ${rawChunkStr}`);
+              // Collect raw chunks in stdout for now
+              stdoutChunks.push(chunk);
             }
           } catch (e: any) {
-            console.error("Error processing chunk for client stream:", e);
+            console.error("Error processing chunk for client stream or server log:", e);
             controller.enqueue(`LOG_ERROR: Error processing Docker log chunk: ${e.message}`);
           }
         });


### PR DESCRIPTION
This commit enhances the script execution output feature.

Client-Side (UI) Enhancements:
- The "Script Execution Output" is now unified for both simple and advanced modes.
- The Docker command (or equivalent) used to run the script is displayed in the UI.
- The "Docker Stream (to client, type ...)" prefix has been removed from logs displayed in the UI.
- Script logs are now processed with specific prefixes from the backend (DOCKER_COMMAND:, LOG:, LOG_ERROR:) for clear presentation. Stderr (error) messages are displayed as raw messages.

Backend API & Server-Side Logging Refinements:
- The backend API (`/api/execute`) now sends the Docker command to the client via the stream.
- It prefixes script stdout with "LOG:" and stderr with "LOG_ERROR:" for the client.
- Server-side console logging of the script's output (from Docker) has been refined:
    - The "Docker Stream (to client, type ...)" prefix is removed.
    - Stderr output from the script is now printed in red to the server's console for better visibility.
    - Trailing newlines are handled to prevent double newlines in server logs.

These changes provide a cleaner, more informative, and consistent script execution output experience, both in the client UI and in the server console.