### PR TITLE
feat: Display pre_docker_run.sh output and Docker command in UI

### DIFF
--- a/crewai-web-ui/src/app/api/execute/route.ts
+++ b/crewai-web-ui/src/app/api/execute/route.ts
@@ -428,46 +428,89 @@ export async function POST(request: Request) {
         const stdoutChunks: Buffer[] = [];
         const stderrChunks: Buffer[] = [];
 
+        // Markers for pre-Docker script log differentiation
+        const PRE_DOCKER_START_MARKER = "--- Running pre_docker_run.sh ---";
+        const PRE_DOCKER_END_MARKER_PREFIX = "--- pre_docker_run.sh finished with exit code ";
+        const PRE_DOCKER_SKIP_MARKER = "--- /workspace/pre_docker_run.sh not found, skipping. ---";
+
+        let inPreDockerScript = false;
+        let preDockerScriptFinished = false;
+
         dockerStream!.on('data', (chunk: Buffer) => {
           try {
             if (chunk.length > 8) {
-              const type = chunk[0];
+              const type = chunk[0]; // 1 for stdout, 2 for stderr
               const payload = chunk.slice(8);
               const payloadString = payload.toString('utf-8');
 
-              // Server-side console logging (as per new feedback)
+              // Server-side console logging (remains unchanged)
               if (type === 2) { // stderr
-                // ANSI escape code for red text
                 console.log(`[31m%s[0m`, payloadString.endsWith('\n') ? payloadString.slice(0, -1) : payloadString);
-              } else { // stdout and other types
+              } else { // stdout
                 console.log(payloadString.endsWith('\n') ? payloadString.slice(0, -1) : payloadString);
               }
 
-              // Existing client-side enqueue logic
-              if (type === 1) { // stdout
-                controller.enqueue(`LOG: ${payloadString}`);
-                stdoutChunks.push(payload);
-              } else if (type === 2) { // stderr
-                controller.enqueue(`LOG_ERROR: ${payloadString}`);
-                stderrChunks.push(payload);
-              } else {
-                controller.enqueue(`LOG_UNKNOWN_TYPE_${type}: ${payloadString}`);
-                // Still collect unknown types in stdout for now, or create a separate bucket
-                stdoutChunks.push(payload);
+              // Logic to identify pre-Docker script phase
+              if (!preDockerScriptFinished) {
+                if (payloadString.includes(PRE_DOCKER_START_MARKER)) {
+                  inPreDockerScript = true;
+                }
+                if (payloadString.includes(PRE_DOCKER_SKIP_MARKER)) {
+                  preDockerScriptFinished = true; // Script is skipped
+                  inPreDockerScript = false; // Ensure not in pre-docker if skipped
+                }
+                // Check if the payloadString itself starts with the end marker prefix,
+                // not just contains it, to avoid partial matches within log lines.
+                if (inPreDockerScript && payloadString.startsWith(PRE_DOCKER_END_MARKER_PREFIX)) {
+                  inPreDockerScript = false;
+                  preDockerScriptFinished = true;
+                }
               }
-            } else {
-              // For very short chunks (unexpected with TTY=false, but handle defensively)
+
+              // Client-side enqueue logic with prefixing
+              if (inPreDockerScript) {
+                if (type === 1) { // stdout from pre-docker script
+                  controller.enqueue(`PRE_DOCKER_LOG: ${payloadString}`);
+                  stdoutChunks.push(payload); // Still collect for final processing
+                } else if (type === 2) { // stderr from pre-docker script
+                  controller.enqueue(`PRE_DOCKER_ERROR: ${payloadString}`);
+                  stderrChunks.push(payload); // Still collect for final processing
+                } else { // Should not happen with Docker's TTY stream format
+                  controller.enqueue(`PRE_DOCKER_UNKNOWN_TYPE_${type}: ${payloadString}`);
+                  stdoutChunks.push(payload);
+                }
+              } else { // Main script logs or logs after pre-docker script finished/skipped
+                if (type === 1) { // stdout
+                  controller.enqueue(`LOG: ${payloadString}`);
+                  stdoutChunks.push(payload);
+                } else if (type === 2) { // stderr
+                  controller.enqueue(`LOG_ERROR: ${payloadString}`);
+                  stderrChunks.push(payload);
+                } else { // Should not happen
+                  controller.enqueue(`LOG_UNKNOWN_TYPE_${type}: ${payloadString}`);
+                  stdoutChunks.push(payload);
+                }
+              }
+            } else { // For very short/raw chunks
               const rawChunkStr = chunk.toString('utf-8');
-              // Server-side log for raw/short chunk
-              console.log(rawChunkStr.endsWith('\n') ? rawChunkStr.slice(0, -1) : rawChunkStr);
-              // Client-side enqueue for raw/short chunk
-              controller.enqueue(`LOG_RAW: ${rawChunkStr}`);
-              // Collect raw chunks in stdout for now
-              stdoutChunks.push(chunk);
+              console.log(rawChunkStr.endsWith('\n') ? rawChunkStr.slice(0, -1) : rawChunkStr); // Server log
+              // For client, decide if these raw chunks also need pre-docker prefixing,
+              // though they are less likely to contain the markers.
+              // For now, assume they are part of the current phase.
+              if (inPreDockerScript) {
+                controller.enqueue(`PRE_DOCKER_LOG_RAW: ${rawChunkStr}`);
+              } else {
+                controller.enqueue(`LOG_RAW: ${rawChunkStr}`);
+              }
+              // Collect raw chunks based on current phase understanding, or just always to stdoutChunks
+              // This part might need refinement if raw chunks are common and need strict separation
+              if (inPreDockerScript && chunk[0] === 2) stderrChunks.push(chunk); else stdoutChunks.push(chunk);
             }
           } catch (e: any) {
             console.error("Error processing chunk for client stream or server log:", e);
-            controller.enqueue(`LOG_ERROR: Error processing Docker log chunk: ${e.message}`);
+            // Send error with context if possible
+            const errorPrefix = inPreDockerScript ? "PRE_DOCKER_ERROR" : "LOG_ERROR";
+            controller.enqueue(`${errorPrefix}: Error processing Docker log chunk: ${e.message}`);
           }
         });
 

--- a/crewai-web-ui/src/app/page.tsx
+++ b/crewai-web-ui/src/app/page.tsx
@@ -362,6 +362,10 @@ export default function Home() {
         for (const line of lines) {
           if (line.startsWith("DOCKER_COMMAND: ")) {
             setDockerCommandToDisplay(line.substring("DOCKER_COMMAND: ".length));
+          } else if (line.startsWith("PRE_DOCKER_LOG: ")) {
+            setScriptLogOutput(prev => [...prev, "PRE_DOCKER_RUN: " + line.substring("PRE_DOCKER_LOG: ".length)]);
+          } else if (line.startsWith("PRE_DOCKER_ERROR: ")) {
+            setScriptLogOutput(prev => [...prev, "PRE_DOCKER_RUN_ERROR: " + line.substring("PRE_DOCKER_ERROR: ".length)]);
           } else if (line.startsWith("LOG: ")) {
             setScriptLogOutput(prev => [...prev, line.substring("LOG: ".length)]);
           } else if (line.startsWith("LOG_ERROR: ")) {
@@ -400,6 +404,10 @@ export default function Home() {
       // Process any remaining buffer content
       if (buffer.startsWith("DOCKER_COMMAND: ")) {
         setDockerCommandToDisplay(buffer.substring("DOCKER_COMMAND: ".length));
+      } else if (buffer.startsWith("PRE_DOCKER_LOG: ")) {
+        setScriptLogOutput(prev => [...prev, "PRE_DOCKER_RUN: " + buffer.substring("PRE_DOCKER_LOG: ".length)]);
+      } else if (buffer.startsWith("PRE_DOCKER_ERROR: ")) {
+        setScriptLogOutput(prev => [...prev, "PRE_DOCKER_RUN_ERROR: " + buffer.substring("PRE_DOCKER_ERROR: ".length)]);
       } else if (buffer.startsWith("LOG: ")) {
         setScriptLogOutput(prev => [...prev, buffer.substring("LOG: ".length)]);
       } else if (buffer.startsWith("LOG_ERROR: ")) {


### PR DESCRIPTION
This commit introduces changes to display the output of the `pre_docker_run.sh` script and the Docker command in the web UI.

Backend (`crewai-web-ui/src/app/api/execute/route.ts`):
- I modified the Docker log streaming logic to differentiate between output from `pre_docker_run.sh` and the main execution script.
- Output lines from `pre_docker_run.sh` are now prefixed with `PRE_DOCKER_LOG:` (for stdout) and `PRE_DOCKER_ERROR:` (for stderr) when sent to you.
- The Docker command used for execution is also explicitly sent to you via the stream, prefixed with `DOCKER_COMMAND:`.

Frontend (`crewai-web-ui/src/app/page.tsx`):
- I updated the script execution log handling to recognize the new prefixes.
- Logs from `pre_docker_run.sh` are now displayed in the execution output area, prefixed with "PRE_DOCKER_RUN: " or "PRE_DOCKER_RUN_ERROR: " for clarity.
- The Docker command received from the backend is displayed above the execution logs.

These changes enhance visibility into the script execution process, allowing you to see the Docker command being used and the output from the preliminary `pre_docker_run.sh` script, similar to how main script output is handled.