### PR TITLE
I made the following changes to address the Ollama API timeout and a …

### DIFF
--- a/crewai-web-ui/src/app/api/generate/route.ts
+++ b/crewai-web-ui/src/app/api/generate/route.ts
@@ -7,6 +7,8 @@ import { interactWithLLM } from './llm.service'; // Import the refactored functi
 
 // Main API Handler
 export async function POST(request: Request) {
+  let llmInputPromptContent = "";
+  let llmOutputPromptContent = "";
   try {
     const body = await request.json();
     const {
@@ -50,8 +52,6 @@ export async function POST(request: Request) {
 
       const inputFilePath = path.join(process.cwd(), 'llm_input_prompt.txt');
       const outputFilePath = path.join(process.cwd(), 'llm_output_prompt.txt');
-      let llmInputPromptContent = "";
-      let llmOutputPromptContent = "";
 
       try {
         llmInputPromptContent = await fs.readFile(inputFilePath, 'utf-8');


### PR DESCRIPTION
…ReferenceError in the error handling:

- In `llm.service.ts`, I've added a 300-second timeout to the Ollama API fetch request. This uses an AbortController and handles AbortError to prevent the request from hanging indefinitely.
- In `route.ts`, I've ensured that `llmInputPromptContent` and `llmOutputPromptContent` are declared at the beginning of the POST function. This makes sure they are available in the error handling catch block, which resolves a ReferenceError that was happening when an error occurred during the interaction with the language model.