### PR TITLE
feat: Add live timers for LLM requests and script execution

### DIFF
--- a/crewai-web-ui/src/app/components/Timer.tsx
+++ b/crewai-web-ui/src/app/components/Timer.tsx
@@ -1,0 +1,68 @@
+// crewai-web-ui/src/app/components/Timer.tsx
+"use client";
+
+import { useState, useEffect, useRef } from 'react';
+
+interface TimerProps {
+  isRunning: boolean;
+  className?: string;
+}
+
+const Timer: React.FC<TimerProps> = ({ isRunning, className }) => {
+  const [seconds, setSeconds] = useState(0);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (isRunning) {
+      // Reset timer only if it was not already running and just started.
+      // This prevents resetting if a parent component re-renders but isRunning remains true.
+      if (!intervalRef.current) {
+        setSeconds(0);
+      }
+      // Clear any existing interval before starting a new one.
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+      intervalRef.current = setInterval(() => {
+        setSeconds(prevSeconds => prevSeconds + 1);
+      }, 1000);
+    } else {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      // When stopping, we keep the seconds. It will be reset if started again.
+      // If you want the timer to show 00:00 as soon as it stops, add setSeconds(0) here.
+    }
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [isRunning]);
+
+  const formatTime = (totalSeconds: number): string => {
+    const minutes = Math.floor(totalSeconds / 60);
+    const remainingSeconds = totalSeconds % 60;
+    const paddedMinutes = String(minutes).padStart(2, '0');
+    const paddedSeconds = String(remainingSeconds).padStart(2, '0');
+    return `${paddedMinutes}:${paddedSeconds}`;
+  };
+
+  // Only render the timer if it's running, or if it has run and stopped (seconds > 0),
+  // or if it's meant to be displayed even when stopped at 0 (e.g. if isRunning is true but seconds is still 0 briefly).
+  // The primary condition for rendering is whether the timer is active (isRunning)
+  // or if it has a non-zero value to display after stopping.
+  if (!isRunning && seconds === 0) {
+    return null; // Don't display anything if not running and timer is at 0 and never ran.
+  }
+
+  return (
+    <span className={className || ''}>
+      {formatTime(seconds)}
+    </span>
+  );
+};
+
+export default Timer;

--- a/crewai-web-ui/src/app/page.tsx
+++ b/crewai-web-ui/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import CopyButton from './components/CopyButton';
+import Timer from './components/Timer'; // <-- Add this line
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { atomDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
@@ -78,6 +79,8 @@ export default function Home() {
   const [defaultPhase1PromptText, setDefaultPhase1PromptText] = useState<string>("");
   const [defaultPhase2PromptText, setDefaultPhase2PromptText] = useState<string>("");
   const [defaultPhase3PromptText, setDefaultPhase3PromptText] = useState<string>("");
+
+  const isLlmTimerRunning = isLoading || !!isLoadingPhase[1] || !!isLoadingPhase[2] || !!isLoadingPhase[3];
 
   useEffect(() => {
     // Load initialInput from cookie on component mount using helper
@@ -621,8 +624,17 @@ export default function Home() {
         {modelsError && <p className="text-sm text-red-600 dark:text-red-400 mt-1">{modelsError}</p>}
       </div>
 
+      {/* LLM Request Timer */}
+      {isLlmTimerRunning && (
+        <div className="mt-4 mb-4 p-3 border border-blue-300 dark:border-blue-700 rounded-md bg-blue-50 dark:bg-blue-900/30 shadow-sm text-center">
+          <p className="text-sm text-blue-700 dark:text-blue-300">
+            LLM Request Timer: <Timer isRunning={isLlmTimerRunning} className="inline font-semibold" />
+          </p>
+        </div>
+      )}
+
       {/* LLM Request Duration Display */}
-      {llmRequestDuration !== null && (
+      {llmRequestDuration !== null && !isLlmTimerRunning && (
         <div className="mt-4 mb-4 p-3 border border-slate-300 dark:border-slate-700 rounded-md bg-slate-50 dark:bg-slate-800 shadow-sm text-center">
           <p className="text-sm text-slate-700 dark:text-slate-300">
             LLM request took: <span className="font-semibold">{llmRequestDuration.toFixed(2)}</span> seconds
@@ -853,8 +865,17 @@ export default function Home() {
                   </pre>
                 </div>
               )}
+              {/* Script Execution Timer */}
+              {isExecutingScript && (
+                <div className="mt-2 mb-2 p-2 border border-green-300 dark:border-green-700 rounded-md bg-green-50 dark:bg-green-900/30 shadow-sm text-center">
+                  <p className="text-xs text-green-700 dark:text-green-300">
+                    Script Execution Timer: <Timer isRunning={isExecutingScript} className="inline font-semibold" />
+                  </p>
+                </div>
+              )}
+
               {/* Script Execution Duration Display */}
-              {scriptExecutionDuration !== null && (
+              {scriptExecutionDuration !== null && !isExecutingScript && (
                 <div className="mt-2 mb-2 p-2 border border-slate-200 dark:border-slate-600 rounded-md bg-slate-100 dark:bg-slate-700 shadow-sm text-center">
                   <p className="text-xs text-slate-600 dark:text-slate-300">
                     Script execution took: <span className="font-semibold">{scriptExecutionDuration.toFixed(2)}</span> seconds


### PR DESCRIPTION
I've integrated a new Timer component into the web UI to display live elapsed time during LLM requests and script execution.

Key changes:
- I created `Timer.tsx`: A reusable React component that displays time in MM:SS format and updates every second when active. It takes an `isRunning` prop to control its state and a `className` prop for styling.
- I modified `page.tsx`:
    - I imported and utilized the `Timer` component for two separate instances: 1. LLM requests: Timer is active when `isLoading` (simple mode) or `isLoadingPhase[N]` (advanced mode) is true. 2. Script execution: Timer is active when `isExecutingScript` is true.
    - I styled the timers with distinct colors (blue for LLM, green for script) and placed them near the existing duration displays.
    - The existing final duration displays (e.g., "LLM request took: X.XX seconds") are now shown only after the respective live timer is no longer active.
- I refined `Timer.tsx` to use a `span` as its root element for better inline styling with labels and improved interval management logic for robustness.

This enhancement provides you with real-time feedback on the duration of ongoing operations.