### PR TITLE
Fix: Correct syntax error in promptUtils.ts

### DIFF
--- a/crewai-web-ui/src/utils/promptUtils.ts
+++ b/crewai-web-ui/src/utils/promptUtils.ts
@@ -6,20 +6,22 @@ export const buildPrompt = (
 ): string => {
   const parts: string[] = [];
 
+  // Condition 1: phase1Text is not null and not just whitespace
   if (phase1Text && phase1Text.trim() !== "") {
     parts.push(`
 
 User Instruction: @@@${userInput}@@@
 ${phase1Text}`);
-  } else if (phase1Text !== null && phase1Text.trim() === "" && (phase2Text === null || phase2Text.trim() === "") && (phase3Text === null || phase3Text.trim() === "")) {
-    // If phase1Text is the *only* text provided and it's empty (or whitespace),
-    // still prepend user instruction to ensure it's captured.
+  }
+  // Condition 2: phase1Text is an empty string, AND it's the ONLY phase text provided.
+  else if (phase1Text !== null && phase1Text.trim() === "" &&
+           (phase2Text === null || phase2Text.trim() === "") &&
+           (phase3Text === null || phase3Text.trim() === "")) {
     parts.push(`
 
 User Instruction: @@@${userInput}@@@
 ${phase1Text}`);
   }
-
 
   if (phase2Text && phase2Text.trim() !== "") {
     parts.push(phase2Text);
@@ -29,7 +31,5 @@ ${phase1Text}`);
     parts.push(phase3Text);
   }
 
-  return parts.join("
-
-");
+  return parts.join("\n\n"); // Corrected line
 };


### PR DESCRIPTION
I resolved an "Unterminated string constant" error in the `buildPrompt` function within `src/utils/promptUtils.ts`. The error was caused by an improperly formatted string literal in the `parts.join()` statement.

The line `return parts.join("..."` was corrected to `return parts.join("\n\n");` to ensure the string literal for the newline separator is correctly formed.

This fix allows `buildPrompt` to be properly exported and imported, resolving the compilation failures you previously observed.