### PR TITLE
feat: Implement Multi-Step LLM execution mode

### DIFF
--- a/crewai-web-ui/src/app/api/generate/route.ts
+++ b/crewai-web-ui/src/app/api/generate/route.ts
@@ -22,31 +22,44 @@ export async function POST(request: Request) {
     if (!llmModel || !fullPrompt) {
       return NextResponse.json({ error: "Missing required parameters: llmModel and fullPrompt." }, { status: 400 });
     }
-    if (mode !== 'simple' && mode !== 'advanced') {
+    if (mode !== 'simple' && mode !== 'advanced') { // Frontend sends 'advanced' for multi-step phases
       return NextResponse.json({ error: "Invalid 'mode'. Must be 'simple' or 'advanced'." }, { status: 400 });
     }
-    if (mode === 'advanced' && (runPhase !== 1 && runPhase !== 2 && runPhase !== 3)) {
-      return NextResponse.json({ error: "Invalid 'runPhase' for advanced mode. Must be 1, 2, or 3." }, { status: 400 });
+    // For traditional advanced mode, runPhase must be 1, 2, or 3.
+    // For multi-step (which arrives as mode: 'advanced'), runPhase might be undefined or could be the actual phase index.
+    // We'll handle the undefined case specifically for multi-step.
+    if (mode === 'advanced' && runPhase !== undefined && (runPhase < 1 || runPhase > 3) && typeof runPhase === 'number') {
+       // This condition is for the original 3-phase advanced mode.
+       // If runPhase is undefined, it could be a multi-step phase.
+      console.warn(`Received runPhase='${runPhase}' for 'advanced' mode. This is only strictly validated for the original 3-phase flow.`);
+      // No strict error return here to allow flexibility for multi-step phases if frontend sends actual phase index.
     }
      if (mode === 'simple' && runPhase !== undefined && runPhase !== null) {
-      // runPhase is not expected for simple mode, but not treating as critical error, just log.
       console.warn(`Received runPhase='${runPhase}' for simple mode. This is not typically expected.`);
     }
 
-
-    // Simplified logging
+    // Logging
     console.log(`Received request: mode='${mode}', llmModel='${llmModel}', fullPrompt length: ${fullPrompt.length}`);
     if (mode === 'advanced') {
-      console.log(`Advanced mode phase: ${runPhase}`);
+      if (runPhase === undefined) {
+        console.log("Processing a phase for Multi-Step execution (mode='advanced', runPhase=undefined).");
+      } else {
+        console.log(`Advanced mode (single-step or multi-step with phase index) phase: ${runPhase}`);
+      }
     }
 
     // The fullPrompt is now received directly from the client.
-    // No need to call readPromptFile or constructPrompt on the backend.
-
     try {
-      // Call interactWithLLM with the fullPrompt received from the client
-      // fs and path imports for GoogleGenerativeAI and OpenAI are handled within llm.service.ts
-      const { llmResponseText, generatedScript: llmGeneratedScript, duration } = await interactWithLLM(fullPrompt, llmModel, mode, runPhase);
+      // Determine the effective runPhase for interactWithLLM
+      // For multi-step phases (arriving as mode: 'advanced', runPhase: undefined from current frontend logic),
+      // we want raw output, similar to phase 1 or 2 of the original advanced mode.
+      // So, we map `runPhase: undefined` to `1` for `interactWithLLM`.
+      // If frontend sends an actual phase index (e.g. 1, 2, 3, 4...) for multi-step,
+      // and if `interactWithLLM` needs a specific value for raw output, this logic might need adjustment.
+      // For now, if runPhase is undefined, it's a multi-step phase call needing raw output.
+      const effectiveRunPhaseForLLM = (mode === 'advanced' && runPhase === undefined) ? 1 : runPhase;
+
+      const { llmResponseText, generatedScript: llmGeneratedScript, duration } = await interactWithLLM(fullPrompt, llmModel, mode, effectiveRunPhaseForLLM);
       let generatedScript = llmGeneratedScript; // Optional, changed to let
 
       const inputFilePath = path.join(process.cwd(), 'llm_input_prompt.txt');
@@ -67,33 +80,50 @@ export async function POST(request: Request) {
       }
 
       // Return structure now includes the fullPrompt that was sent in the request
-      if (mode === 'advanced' && (runPhase === 1 || runPhase === 2)) {
+      // For multi-step (mode='advanced', runPhase=undefined from frontend), this block will be used.
+      // It returns the raw 'output', which is what a multi-step phase needs.
+      // The `phase` property in response might be `undefined` if `runPhase` was undefined.
+      // Or, we can set it to a generic value or the received runPhase if frontend starts sending it for multi-step.
+      if (mode === 'advanced' && (runPhase === undefined || runPhase === 1 || runPhase === 2)) {
+        // If runPhase was undefined (multi-step), we used effectiveRunPhaseForLLM=1.
+        // The response `phase` field can reflect the original runPhase if needed, or be generic.
+        // For now, let's return the original runPhase (which could be undefined).
         return NextResponse.json({ phase: runPhase, output: llmResponseText, fullPrompt: fullPrompt, llmInputPromptContent, llmOutputPromptContent, duration });
       }
+
+      // This handles advanced mode, phase 3 (script generation)
+      if (mode === 'advanced' && runPhase === 3) {
+         return NextResponse.json({ generatedScript, phase: 3, fullPrompt: fullPrompt, llmInputPromptContent, llmOutputPromptContent, duration });
+      }
+
 
       // Ollama-specific LLM configuration injection block removed
       // as injectOllamaConfig has been removed from script.utils.ts
 
       if (generatedScript !== undefined) {
+        // This is for 'simple' mode script generation.
         if (mode === 'simple') {
-          // For simple mode, phasedOutputs might be relevant if the script produces them
-          // However, the current llmResult from interactWithLLM doesn't include phasedOutputs
-          // This might need adjustment if simple mode is expected to also return structured task outputs
-          // directly from the /api/generate call, or if they are only handled by /api/execute
-          return NextResponse.json({ generatedScript, fullPrompt: fullPrompt, llmInputPromptContent, llmOutputPromptContent, duration /* phasedOutputs: [] an example if needed */ });
-        } else { // Advanced mode, phase 3
-          return NextResponse.json({ generatedScript, phase: 3, fullPrompt: fullPrompt, llmInputPromptContent, llmOutputPromptContent, duration /* phasedOutputs: [] an example if needed */ });
+          return NextResponse.json({ generatedScript, fullPrompt: fullPrompt, llmInputPromptContent, llmOutputPromptContent, duration });
         }
-      } else {
-        // This case should ideally not be reached if llmModel.startsWith('ollama/') and generatedScript was initially undefined,
-        // as the injection logic itself checks for generatedScript.
-        // However, if generatedScript was undefined from llmResult and it's not an Ollama model, this path is valid.
-        console.error(`Error: generatedScript is undefined for mode='${mode}' and runPhase='${runPhase}'. This should not happen if a script was expected.`);
-        return NextResponse.json({ error: "Failed to process LLM output for script generation.", llmInputPromptContent, llmOutputPromptContent }, { status: 500 });
+        // Note: mode 'advanced' runPhase 3 is handled above.
+        // Other cases for generatedScript (if any) would need specific handling.
+      } else if (mode === 'advanced' && runPhase !== 3) {
+        // This case implies mode is 'advanced' but it's not phase 1, 2 (raw output) or 3 (script).
+        // This shouldn't happen with current frontend logic if runPhase is undefined, 1 or 2 for raw output.
+        // If runPhase is a multi-step index > 3 and NOT meant to be a script, it should have been handled by the raw output block.
+        // This path indicates an unexpected state for 'advanced' mode if a script wasn't generated.
+        console.warn(`Warning: generatedScript is undefined for advanced mode phase ${runPhase}, but not phase 1 or 2. LLM output was: ${llmResponseText}`);
+        // Fallback to returning the raw text as output if no script was generated, and it wasn't phase 1 or 2.
+        return NextResponse.json({ phase: runPhase, output: llmResponseText, fullPrompt: fullPrompt, llmInputPromptContent, llmOutputPromptContent, duration });
+
+      } else if (mode === 'simple' && !generatedScript) {
+         console.error(`Error: generatedScript is undefined for mode='simple'. LLM output was: ${llmResponseText}`);
+         return NextResponse.json({ error: "Failed to process LLM output for script generation in simple mode.", llmInputPromptContent, llmOutputPromptContent, output: llmResponseText }, { status: 500 });
       }
 
+
     } catch (apiError) {
-      console.error(`Error interacting with LLM for model ${llmModel}:`, apiError);
+      console.error(`Error interacting with LLM for model ${llmModel} (mode: ${mode}, runPhase: ${runPhase}):`, apiError);
       const message = apiError instanceof Error ? apiError.message : String(apiError);
       return NextResponse.json({ error: message, fullPrompt: fullPrompt, llmInputPromptContent, llmOutputPromptContent }, { status: 500 }); // Include fullPrompt for client debugging
     }


### PR DESCRIPTION
This introduces a "Multi-Step" execution mode for interactions with me, allowing for a sequence of phases where each phase builds upon the output of the previous one.

Key changes:

-   **Frontend (`page.tsx`):**
    -   I've added a UI toggle so you can switch between "Single Step" and "Multi-Step" modes.
    -   In "Multi-Step" mode, you can define multiple phases, each with its own prompt.
    -   The output of phase N-1 is used as input for phase N's prompt.
    -   Each phase displays its own timer during execution and its final duration.
    -   I've implemented `handleMultiStepSubmit` to orchestrate sequential API calls for each phase.
    -   I've updated state management to handle multi-step phase data (prompts, outputs, errors, timers).

-   **Backend API (`generate/route.ts`):**
    -   I've modified this to correctly handle individual phase requests for the "Multi-Step" mode.
    -   These requests are processed to ensure raw output is returned for each phase.

-   **LLM Service (`llm.service.ts`):**
    -   I've verified this is compatible with the frontend-orchestrated multi-step approach, providing raw output and duration for each phase without needing recursive logic internally.

-   **Prompt Utilities (`promptUtils.ts`):**
    -   I've reviewed this to ensure `buildPrompt` continues to serve the "Single Step" Advanced mode correctly, while "Multi-Step" mode uses its own internal prompt construction logic in `page.tsx`.

This feature allows you to create more complex, chained workflows directly within the UI.