### PR TITLE
Fix: Resolve multiple build failures

### DIFF
--- a/crewai-web-ui/next.config.ts
+++ b/crewai-web-ui/next.config.ts
@@ -2,12 +2,25 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: 'standalone',
-  webpack: (config, { isServer }) => {
+  webpack: (config, { isServer, webpack }) => { // Added webpack to access webpack.IgnorePlugin
     // Add a rule to handle .node files using node-loader
     config.module.rules.push({
       test: /\.node$/,
       use: 'node-loader',
     });
+
+    // Mark ssh2 as external to avoid bundling issues on the server
+    if (isServer) {
+      if (!config.externals) {
+        config.externals = [];
+      }
+      // Ensure we are using the array form of externals
+      if (Array.isArray(config.externals)) {
+         config.externals.push({
+           'ssh2': 'commonjs ssh2',
+         });
+      }
+    }
 
     // Important: return the modified config
     return config;

--- a/crewai-web-ui/src/app/api/execute/stream.service.ts
+++ b/crewai-web-ui/src/app/api/execute/stream.service.ts
@@ -148,8 +148,8 @@ export function handleDockerStream(
             overallStatus: 'failure',
             error: `Error during final processing: ${e.message}`,
             preHostRun: preHostRunResult,
-            preDockerRun: { stdout: Buffer.concat(stdoutChunks).toString('utf-8'), stderr: Buffer.concat(stderrChunks).toString('utf-8'), status: 'unknown', error: `Error during final processing: ${e.message}` },
-            mainScript: { stdout: '', stderr: '', status: 'unknown', error: `Error during final processing: ${e.message}` },
+            preDockerRun: { stdout: Buffer.concat(stdoutChunks).toString('utf-8'), stderr: Buffer.concat(stderrChunks).toString('utf-8'), status: 'failure', error: `Error during final processing: ${e.message}` },
+            mainScript: { stdout: '', stderr: '', status: 'failure', error: `Error during final processing: ${e.message}` },
             scriptExecutionDuration: scriptExecutionDuration, // Include duration in error
           };
           try {

--- a/crewai-web-ui/src/app/api/execute/types.ts
+++ b/crewai-web-ui/src/app/api/execute/types.ts
@@ -12,6 +12,7 @@ export interface ExecutionResult {
   mainScript?: StageOutput;
   overallStatus: 'success' | 'failure';
   error?: string; // For top-level errors like Docker build failure or unhandled exceptions
+  scriptExecutionDuration?: number; // Added this line
 }
 
 // Interface for the return type of the modified executePythonScript

--- a/crewai-web-ui/src/app/api/generate/llm.service.ts
+++ b/crewai-web-ui/src/app/api/generate/llm.service.ts
@@ -1,7 +1,7 @@
 import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
 import OpenAI from 'openai'; // Added for DeepSeek
 import fs from 'fs/promises';
-import { getAllModels, ModelConfig } from '../../../../config/models.config';
+import { getAllModels, ModelConfig } from '../../../config/models.config';
 import path from 'path';
 import { extractScript } from './script.utils'; // Import the new utility function
 
@@ -107,7 +107,7 @@ export async function interactWithLLM(
     console.log("DeepSeek API call parameters:", deepSeekParams);
     const completion = await openai.chat.completions.create(deepSeekParams);
     console.log("DeepSeek API call completed via OpenAI SDK.");
-    llmResponseText = completion.choices?.[0]?.message?.content;
+    llmResponseText = completion.choices?.[0]?.message?.content ?? '';
     if (!llmResponseText) {
       console.error("DeepSeek API call via OpenAI SDK successful but response format is unexpected or content is missing.", completion);
       throw new Error("DeepSeek API Error (OpenAI SDK): No content generated or unexpected response structure.");


### PR DESCRIPTION
This commit addresses several issues that were causing the `npm run build` command to fail:

1.  **Webpack externals for ssh2**: Modified `next.config.ts` to include `ssh2` in Webpack externals for the server build. This resolves a "Module not found: Can't resolve 'node-loader'" error that occurred due to `ssh2`'s internal require mechanisms.

2.  **Extended ExecutionResult type**: Added the optional field `scriptExecutionDuration?: number` to the `ExecutionResult` interface in `src/app/api/execute/types.ts`. This fixes a type error where this property was being assigned but not declared.

3.  **Corrected import path**: Fixed an incorrect relative import path for `models.config` in `src/app/api/generate/llm.service.ts`. Changed `../../../../config/models.config` to `../../../config/models.config`.

4.  **Handled invalid status type**: In `src/app/api/execute/stream.service.ts`, an error handling path was attempting to set `status: 'unknown'`, which is not a valid type for `StageOutput['status']`. This was changed to `status: 'failure'`.

5.  **Ensured string assignment**: In `src/app/api/generate/llm.service.ts`, handled a potential null value from `part.text` by adding a nullish coalescing operator (`?? ''`) before assigning to `llmResponseText`, ensuring it always receives a string.

With these changes, the `npm run build` command for `crewai-web-ui` now completes successfully.