### PR TITLE
Feat: Cache LLM model selection in cookies

### DIFF
--- a/crewai-web-ui/src/app/page.tsx
+++ b/crewai-web-ui/src/app/page.tsx
@@ -142,9 +142,15 @@ export default function Home() {
     // scriptErrorSoundRef.current.load();
 
     // Load initialInput from cookie on component mount using helper
-    const cookieValue = getCookie('initialInstruction');
-    if (cookieValue) {
-      setInitialInput(cookieValue);
+    const initialInstructionCookie = getCookie('initialInstruction');
+    if (initialInstructionCookie) {
+      setInitialInput(initialInstructionCookie);
+    }
+
+    // Load llmModelSelection from cookie
+    const llmModelCookie = getCookie('llmModelSelection');
+    if (llmModelCookie) {
+      setLlmModel(llmModelCookie);
     }
   }, []); // Empty dependency array ensures this runs only on mount
 
@@ -291,6 +297,7 @@ export default function Home() {
 
   const handleMultiStepPhaseExecution = async (phase: number) => {
     setCookie('initialInstruction', initialInput, 30); // Persist initial input
+    setCookie('llmModelSelection', llmModel, 30); // Persist LLM model selection
     if (!llmModel) {
       setError("Please select an LLM model.");
       return;
@@ -470,6 +477,7 @@ export default function Home() {
 
   const handleSimpleModeSubmit = async () => {
     setCookie('initialInstruction', initialInput, 30);
+    setCookie('llmModelSelection', llmModel, 30); // Persist LLM model selection
     if (!llmModel) {
       setError("Please select an LLM model.");
       return;
@@ -492,6 +500,7 @@ export default function Home() {
 
   const handleSimpleModeMultiStepSubmit = async () => {
     setCookie('initialInstruction', initialInput, 30);
+    setCookie('llmModelSelection', llmModel, 30); // Persist LLM model selection
     if (!llmModel) {
       setError("Please select an LLM model.");
       return;
@@ -616,6 +625,7 @@ export default function Home() {
 
   const handleRunPhase = async (phase: number) => {
     setCookie('initialInstruction', initialInput, 30);
+    setCookie('llmModelSelection', llmModel, 30); // Persist LLM model selection
     if (!llmModel) {
       setError("Please select an LLM model.");
       return;


### PR DESCRIPTION
Implemented caching for the LLM model selection using browser cookies, replicating the existing pattern for caching the initial user instruction.

Changes include:
- Modified the main useEffect hook in `page.tsx` to load the `llmModelSelection` from a cookie on component mount.
- Updated `handleSimpleModeSubmit`, `handleRunPhase`, `handleMultiStepPhaseExecution`, and `handleSimpleModeMultiStepSubmit` functions to save the selected LLM model to the `llmModelSelection` cookie.