### PR TITLE
Feat: Sync Simple Mode Multi-step results to Multi-Step Mode fields

### DIFF
--- a/crewai-web-ui/src/app/page.tsx
+++ b/crewai-web-ui/src/app/page.tsx
@@ -535,6 +535,10 @@ export default function Home() {
         setSimpleMultiStepPhase1_Duration(phase1Data.duration !== undefined ? phase1Data.duration : null);
         setActualLlmOutputPrompt(phase1Data.llmOutputPromptContent || "");
 
+        // Populate Multi-Step Mode fields for Phase 1
+        setMultiStepPhase1_Input(phase1PromptValue);
+        setMultiStepPhase1_Output(phase1DataOutput || "");
+
         if (phase1DataOutput && phase1DataOutput.trim() !== "") {
           // --- Phase 2 ---
           setIsLoadingSimpleMultiStepPhase2(true);
@@ -559,6 +563,10 @@ export default function Home() {
               setSimpleMultiStepPhase2_Duration(phase2Data.duration !== undefined ? phase2Data.duration : null);
               setActualLlmOutputPrompt(phase2Data.llmOutputPromptContent || "");
 
+              // Populate Multi-Step Mode fields for Phase 2
+              setMultiStepPhase2_Input(phase2PromptValue);
+              setMultiStepPhase2_Output(phase2DataOutput || "");
+
               if (phase2DataOutput && phase2DataOutput.trim() !== "") {
                 // --- Phase 3 ---
                 setIsLoadingSimpleMultiStepPhase3(true);
@@ -582,6 +590,10 @@ export default function Home() {
                     if (phase3Data.phasedOutputs) setPhasedOutputs(phase3Data.phasedOutputs);
                     setActualLlmOutputPrompt(phase3Data.llmOutputPromptContent || "");
 
+                    // Populate Multi-Step Mode fields for Phase 3
+                    setMultiStepPhase3_Input(phase3PromptValue);
+                    setMultiStepPhase3_Output(phase3GeneratedScript || "");
+
                     if (!phase3GeneratedScript || phase3GeneratedScript.trim() === "") {
                       setError("Phase 3 failed to produce a script. Please check the logs or try again.");
                     }
@@ -593,6 +605,7 @@ export default function Home() {
                   },
                   () => { // Phase 3 onFinally
                     setIsLoadingSimpleMultiStepPhase3(false);
+                    setCurrentOperatingMode('multistep'); // Switch to Multi-Step Mode
                   }
                 );
               } else {


### PR DESCRIPTION
When the 'Run Simple Mode with Multi step' button is clicked, the application now captures the input and output for each of the three phases.

After the successful execution of all three phases in the simple multi-step process, the UI automatically switches to the 'Multi-Step Mode' tab. The corresponding input and output fields in the 'Multi-Step Mode' are populated with the values generated during the simple multi-step execution.

This allows users to seamlessly transition from a guided simple multi-step run to the more detailed 'Multi-Step Mode' for further inspection or modification of each phase's results.